### PR TITLE
Fix validation-mixin causing "Uncaught TypeError: base is not a constructor" error

### DIFF
--- a/view/frontend/web/js/validation-mixin.js
+++ b/view/frontend/web/js/validation-mixin.js
@@ -1,7 +1,7 @@
 define(['jquery'], function($) {
     'use strict';
 
-    return function() {
+    return function(target) {
         $.validator.addMethod(
             'alekseon-validate-form-filesize',
             function(v, element, params) {
@@ -39,5 +39,7 @@ define(['jquery'], function($) {
             },
             $.mage.__('File is not an image.')
         )
+
+        return target;
     }
 });


### PR DESCRIPTION
This PR fixes the following console error preventing the checkout from functioning properly:

```
TypeError: base is not a constructor
    at $.widget (widget.js:104:25)
    at validation-ext.js:36:11
    at mixins.js:105:22
    at Array.forEach (<anonymous>)
    at applyMixins (mixins.js:104:16)
    at mixins.js:129:36
    at Object.execCb (require.js:1696:33)
    at context.execCb (resolver.js:156:31)
    at Module.check (require.js:883:51)
    at Module.<anonymous> (require.js:1139:34)
```

Looking at other validator mixins, it looks like the target widget was missing as argument and return value. This is also shown in the examples at https://developer.adobe.com/commerce/frontend-core/guide/validations/custom-rules/

After applying these changes the error is gone and checkout works again.